### PR TITLE
Added copyright|databaseRight properties

### DIFF
--- a/schema/schema.ttl
+++ b/schema/schema.ttl
@@ -102,6 +102,36 @@ odrs:copyrightStatement
     rdfs:domain odrs:RightsStatement;
     rdfs:range foaf:Document.
 
+odrs:databaseRightStatement
+    a owl:ObjectProperty;
+    rdfs:isDefinedBy <http://schema.theodi.org/odrs>;
+    rdfs:label "database right statement"@en;
+    rdfs:comment """A link to a document that includes a statement about the database rights that apply to this dataset. The web page might include both a statement on the applicable rights and any relevant guidance for re-users."""@en;    
+    rdfs:domain odrs:RightsStatement;
+    rdfs:range foaf:Document.
+
+odrs:copyrightHolder
+    a owl:ObjectProperty;
+    rdfs:isDefinedBy <http://schema.theodi.org/odrs>;
+    rdfs:label "copyright holder"@en;
+    rdfs:comment """A reference to the organization that holds copyright over the content of the dataset"""@en;    
+    rdfs:domain odrs:RightsStatement;
+    rdfs:range foaf:Organization.
+
+odrs:databaseRightHolder
+    a owl:ObjectProperty;
+    rdfs:isDefinedBy <http://schema.theodi.org/odrs>;
+    rdfs:label "database right holder"@en;
+    rdfs:comment """A reference to the organization that holds database rights over the dataset"""@en;    
+    rdfs:domain odrs:RightsStatement;
+    rdfs:range foaf:Organization.
+
+odrs:jurisdiction
+    a owl:ObjectProperty;
+    rdfs:isDefinedBy <http://schema.theodi.org/odrs>;
+    rdfs:label "jurisdiction"@en;
+    rdfs:comment """A reference to the jurisdiction in which copyright and/or database rights have been asserts. It is recommended that this refer to the URI for a country or region."""@en;    
+    rdfs:domain odrs:RightsStatement.
 
 ############################################################################
 # Datatype Properties
@@ -122,4 +152,20 @@ odrs:attributionText
     rdfs:comment "The text to use in an attribution link. This may be the name of the publisher or a reference to a community or group of contributors"@en;    
     rdfs:range rdfs:Literal;
     rdfs:domain odrs:RightsStatement.
+
+odrs:copyrightYear
+     a owl:DatatypeProperty;
+     rdfs:isDefinedBy <http://schema.theodi.org/odrs>;
+     rdfs:label "copyright year"@en;
+     rdfs:comment """The year from which copyright over the content of the dataset is asserted."""@en;    
+     rdfs:range rdfs:Literal;
+     rdfs:domain odrs:RightsStatement.
+
+odrs:databaseRightYear
+     a owl:DatatypeProperty;
+     rdfs:isDefinedBy <http://schema.theodi.org/odrs>;
+     rdfs:label "database right year"@en;
+     rdfs:comment """The year from which a database right over the dataset is asserted."""@en;    
+     rdfs:range rdfs:Literal;
+     rdfs:domain odrs:RightsStatement.
 


### PR DESCRIPTION
This request addresses issues #9 and #12 adding some additional properties to the schema:
- copyrightYear & databaseRightYear -- year from which rights are claimed
- copyrightHolder & databaseRightHolder -- URIs that refer to rights holder
- databaseRightStatement -- equivalent to copyrightStatement

I've decided to retain copyrightNotice to allow users to express a copyright or database right notice with a Rights Statement. In practice there's enough variation in formatting (particularly with respect to rights holders) to make this tricky to generate automatically. I think getting buy-in from publishers will be easier if existing text can be directly added.
